### PR TITLE
Fix shebang for MacOS/OSX

### DIFF
--- a/dijnet-dump.sh
+++ b/dijnet-dump.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # dump all dijnet.hu invoices to the actual folder
 #
 # required dependency:


### PR DESCRIPTION
OSX is shipped with 'bash' version 3.2.57, and this can be found on the '/bin/bash' path. Unfortunately this version doesn't recognise nor the 'readarray' neither the "mapfile" builtins.

Some of the users who actively use bash already installed a newer
version (e.g. from ports or homebrew) but this aren't taken into account since those versions are installed on an other path however are registered correctly.

The best solution would be to use '/usr/bin/env' to pick the configured
version of bash.